### PR TITLE
Added how to login with 2FA enabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The app is available in both, [Nextcloud appstore](https://apps.nextcloud.com/ap
 ## :question: Solve encoding errors on MySQL
 If you are on MySQL or MariaDB and have issues with the database, the cause may be that you have to enable 4-byte support. Here is a guide: https://docs.nextcloud.com/server/11/admin_manual/maintenance/mysql_4byte_support.html
 
+## :question: Using the Android App With 2FA Enabled
+If you've enabled 2FA (Two Factor Authentication) logins you may be hit with an incorrect password error. The android client doesn't support logging in with 2FA credentials. Here is a guide to do so, although it says Managing Devices it is the same process for App Passwords: https://docs.nextcloud.com/server/11/user_manual/session_management.html#managing-devices
+
 ## :eyes: Screenshot
 
 ![Screenshot](https://raw.githubusercontent.com/nextcloud/ocsms/master/appinfo/screenshots/1.png)


### PR DESCRIPTION
#157 had a user asking about 2FA support. You're able to login to the app with an app password, but it wasn't well documented. Here is some documentation to remedy that.