### PR TITLE
Fixed Nextcloud 12 compatibility

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
     <dependencies>
         <php min-version="5.6" min-int-size="32"/>
         <owncloud min-version="8.1" max-version="9.2" />
-        <nextcloud min-version="9.0" max-version="11.0" />
+        <nextcloud min-version="9.0" max-version="12.0" />
     </dependencies>
 
     <ocsid>167289</ocsid>

--- a/appinfo/ocsmsapp.php
+++ b/appinfo/ocsmsapp.php
@@ -53,7 +53,7 @@ class OcSmsApp extends App {
         	 */
 		$container->registerService('ConfigMapper', function (IContainer $c) use ($server) {
 			return new ConfigMapper(
-				$server->getDb(),
+				$server->getDatabaseConnection(),
 				$c->query('UserId'),
 				$server->getCrypto()
 			);
@@ -64,12 +64,12 @@ class OcSmsApp extends App {
 		});
 
 		$container->registerService('ConversationStateMapper', function(IContainer $c) use ($server) {
-			return new ConversationStateMapper($server->getDb());
+			return new ConversationStateMapper($server->getDatabaseConnection());
 		});
 
 		$container->registerService('SmsMapper', function(IContainer $c) use ($server) {
 			return new SmsMapper(
-				$server->getDb(),
+				$server->getDatabaseConnection(),
 				$c->query('ConversationStateMapper')
 			);
 		});

--- a/db/configmapper.php
+++ b/db/configmapper.php
@@ -11,7 +11,7 @@
 
 namespace OCA\OcSms\Db;
 
-use \OCP\IDb;
+use \OCP\IDBConnection;
 
 use \OCP\AppFramework\Db\Mapper;
 use \OCP\AppFramework\Db\DoesNotExistException;
@@ -28,7 +28,7 @@ class ConfigMapper extends Mapper {
 	 */
 	private $crypto;
 
-	public function __construct (IDb $db, $user, $crypto){
+	public function __construct (IDBConnection $db, $user, $crypto){
 		parent::__construct($db, 'ocsms_config');
 		$this->user = $user;
 		$this->crypto = $crypto;

--- a/db/conversationstatemapper.php
+++ b/db/conversationstatemapper.php
@@ -11,7 +11,7 @@
 
 namespace OCA\OcSms\Db;
 
-use \OCP\IDb;
+use \OCP\IDBConnection;
 
 use \OCP\AppFramework\Db\Mapper;
 
@@ -19,7 +19,7 @@ use \OCA\OcSms\AppInfo\OcSmsApp;
 use \OCA\OcSms\Lib\PhoneNumberFormatter;
 
 class ConversationStateMapper extends Mapper {
-	public function __construct (IDb $db) {
+	public function __construct (IDBConnection $db) {
 		parent::__construct($db, 'ocsms_smsdatas');
 	}
 

--- a/db/smsmapper.php
+++ b/db/smsmapper.php
@@ -11,7 +11,7 @@
 
 namespace OCA\OcSms\Db;
 
-use \OCP\IDb;
+use \OCP\IDBConnection;
 
 use \OCP\AppFramework\Db\Mapper;
 
@@ -33,7 +33,7 @@ class SmsMapper extends Mapper {
 	);
 	private $convStateMapper;
 
-	public function __construct (IDb $db, ConversationStateMapper $cmapper) {
+	public function __construct (IDBConnection $db, ConversationStateMapper $cmapper) {
 		parent::__construct($db, 'ocsms_smsdatas');
 		$this->convStateMapper = $cmapper;
 	}


### PR DESCRIPTION
Fixes impact of https://github.com/nextcloud/mail/issues/237 in Nextcloud 12 for OCSMS by migrating from `IDb` to `IDBConnection`.

With this PR applied OCSMS runs on Nextcloud 12 Beta 1, therefore I enabled that in `info.xml`.