### PR TITLE
Force the messages container to full width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -187,6 +187,10 @@
 	opacity: 1;
 }
 
+.ocsms-messages-container {
+        width: 100%;
+}
+
 .msg-spacer {
 	clear: both;
 }

--- a/templates/main.php
+++ b/templates/main.php
@@ -79,7 +79,7 @@ use \OCA\OcSms\Lib\CountryCodes;
 		</div>
 		<div id="app-content-wrapper" ng-show="!isConvLoading">
 			<div ng-show="messages.length == 0" id="ocsms-empty-conversation">Please choose a conversation on the left menu</div>
-			<div ng-show="messages.length > 0">
+			<div ng-show="messages.length > 0" class="ocsms-messages-container">
 				<div ng-repeat="message in messages | orderBy:'date'">
 					<div class="msg-{{ message.type }}">
 						<div>{{ message.content }}</div>


### PR DESCRIPTION
if a conversation contains only small text messages, the conversation bubbles may not alight to the right side but only be part way across the display.

This adds a class and width attribute to make sure the conversation is always floats to the far right.