### PR TITLE
Fix the initial display of a conversation

### DIFF
--- a/js/devel/legacy.js
+++ b/js/devel/legacy.js
@@ -171,7 +171,7 @@ app.controller('OcSmsController', ['$scope', '$interval', '$timeout', '$compile'
 
 					/*
 					* Decrement notification step counter, but stop it a zero
-					* Stop at zero permit to notify instanly the user when 
+					* Stop at zero permit to notify instanly the user when
 					* there is new messages in all conversations
 					*/
 
@@ -384,8 +384,16 @@ app.controller('OcSmsController', ['$scope', '$interval', '$timeout', '$compile'
 							$scope.selectedContact.label = urlPhoneNumber;
 							$scope.selectedContact.nav = urlPhoneNumber;
 							$scope.selectedContact.avatar = undefined;
+
+							// Now let's loop through the contact list and see if we can find the rest of the details
+							for (let i = 0; i < $scope.contacts.length; i++) {
+								if( $scope.contacts[i].nav == urlPhoneNumber ) {
+									$scope.selectedContact = $scope.contacts[i];
+									break;
+								}
+							}
 						}
-						$scope.fetchConversation(null);
+						$scope.fetchConversation($scope.selectedContact);
 						Sms.selectConversation($("a[mailbox-navigation='" + urlPhoneNumber + "']"));
 					}
 				}
@@ -393,6 +401,7 @@ app.controller('OcSmsController', ['$scope', '$interval', '$timeout', '$compile'
 			SmsSettings.init();
 			SmsNotifications.init();
 			$scope.checkNewMessages();
+			$scope.refreshConversation();
 		});
 	}
 ]);

--- a/js/devel/legacy.js
+++ b/js/devel/legacy.js
@@ -386,8 +386,8 @@ app.controller('OcSmsController', ['$scope', '$interval', '$timeout', '$compile'
 							$scope.selectedContact.avatar = undefined;
 
 							// Now let's loop through the contact list and see if we can find the rest of the details
-							for ( let i = 0; i < $scope.contacts.length; i++ ) {
-								if ( $scope.contacts[i].nav == urlPhoneNumber ) {
+							for (let i = 0; i < $scope.contacts.length; i++) {
+								if ($scope.contacts[i].nav == urlPhoneNumber) {
 									$scope.selectedContact = $scope.contacts[i];
 									break;
 								}

--- a/js/devel/legacy.js
+++ b/js/devel/legacy.js
@@ -386,8 +386,8 @@ app.controller('OcSmsController', ['$scope', '$interval', '$timeout', '$compile'
 							$scope.selectedContact.avatar = undefined;
 
 							// Now let's loop through the contact list and see if we can find the rest of the details
-							for (let i = 0; i < $scope.contacts.length; i++) {
-								if( $scope.contacts[i].nav == urlPhoneNumber ) {
+							for ( let i = 0; i < $scope.contacts.length; i++ ) {
+								if ( $scope.contacts[i].nav == urlPhoneNumber ) {
 									$scope.selectedContact = $scope.contacts[i];
 									break;
 								}


### PR DESCRIPTION
Look up the contact details if the page has been passed in a phone number as a url parameter on initial page load.

This most commonly occurs when a user reloads the page with a conversation already selected.