### PR TITLE
Fix settings size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -216,6 +216,14 @@
 	display: inline-block;
 }
 
+#app-settings {
+	width: 20%;
+}
+
+#app-settings-header {
+	width: auto;
+}
+
 #app-settings-content .new-button {
 	width: 32px;
 	background-size: 16px;

--- a/templates/main.php
+++ b/templates/main.php
@@ -21,7 +21,9 @@ use \OCA\OcSms\Lib\CountryCodes;
 	</div>
 	<div id="app-settings" class="ng-scope">
 		<div id="app-settings-header">
-			<button name="app settings" class="settings-button" data-apps-slide-toggle="#app-settings-content"></button>
+			<button name="app settings" class="settings-button" data-apps-slide-toggle="#app-settings-content">
+				<?php p($l->t('Settings'));?>
+			</button>
 		</div>
 		<div id="app-settings-content">
 			<div><label for="setting_msg_per_page">Max messages on tab loading</label>


### PR DESCRIPTION
The settings div will overflow the contacts box if the display is narrow as it has a fixed width of 250px but the contacts div is 20% of the display.

Also, add a "Settings" text label to be consistent with other NextCloud core apps.