### PR TITLE
Fix deleting conversations without a contact

### DIFF
--- a/controller/smscontroller.php
+++ b/controller/smscontroller.php
@@ -145,7 +145,7 @@ class SmsController extends Controller {
 		// Contact resolved
 		if ($contactName != "" && isset($iContacts[$contactName])) {
 			// forall numbers in iContacts
-			foreach($iContacts[$contactName] as $cnumber) {
+			foreach ($iContacts[$contactName] as $cnumber) {
 				$messages = $messages +	$this->smsMapper->getAllMessagesForPhoneNumber($this->userId, $cnumber, $configuredCountry, $lastDate);
 				$msgCount += $this->smsMapper->countMessagesForPhoneNumber($this->userId, $cnumber, $configuredCountry);
 				$phoneNumbers[] = PhoneNumberFormatter::format($configuredCountry, $cnumber);
@@ -197,7 +197,7 @@ class SmsController extends Controller {
 		// Contact resolved
 		if ($contactName != "" && isset($iContacts[$contactName])) {
 			// forall numbers in iContacts
-			foreach($iContacts[$contactName] as $cnumber) {
+			foreach ($iContacts[$contactName] as $cnumber) {
 				$this->smsMapper->removeMessagesForPhoneNumber($this->userId, $cnumber);
 			}
 		}
@@ -206,7 +206,7 @@ class SmsController extends Controller {
 			$phlist = $this->smsMapper->getAllPhoneNumbersForFPN($this->userId, $contact, $configuredCountry);
 
 			// Loop through the returned list of phone numbers and delete them.
-			foreach( $phlist as $phnumber => $value) {
+			foreach ($phlist as $phnumber => $value) {
 				$this->smsMapper->removeMessagesForPhoneNumber($this->userId, $phnumber);
 			}
 		}

--- a/controller/smscontroller.php
+++ b/controller/smscontroller.php
@@ -202,7 +202,13 @@ class SmsController extends Controller {
 			}
 		}
 		else {
-			$this->smsMapper->removeMessagesForPhoneNumber($this->userId, $contact);
+			// If we didn't match a contact we need to lookup the raw sms phone numbers associated with the formatted phone number that was passed in as $contact.
+			$phlist = $this->smsMapper->getAllPhoneNumbersForFPN($this->userId, $contact, $configuredCountry);
+
+			// Loop through the returned list of phone numbers and delete them.
+			foreach( $phlist as $phnumber => $value) {
+				$this->smsMapper->removeMessagesForPhoneNumber($this->userId, $phnumber);
+			}
 		}
 		return new JSONResponse(array());
 	}


### PR DESCRIPTION
If a conversation does not have a contact, the delete function will fail as only the formatted phone number is passed in and the raw sms phone number is needed to execute the delete.