### PR TITLE
Fix date used to retrieve new messages

### DIFF
--- a/controller/smscontroller.php
+++ b/controller/smscontroller.php
@@ -110,13 +110,14 @@ class SmsController extends Controller {
 			}
 		}
 		$lastRead = $this->convStateMapper->getLast($this->userId);
+		$lastMessage = $this->smsMapper->getLastTimestamp($this->userId);
 		$ocversion = \OCP\Util::getVersion();
 		$photoversion = 1;
 		if (version_compare($ocversion[0].".".$ocversion[1].".".$ocversion[2], "9.0.0", ">=")) {
 			$photoversion = 2;
 		}
 
-		return new JSONResponse(array("phonelist" => $phoneList, "contacts" => $contacts, "lastRead" => $lastRead, "photos" => $photos, "uids" => $uids, "photo_version" => $photoversion));
+		return new JSONResponse(array("phonelist" => $phoneList, "contacts" => $contacts, "lastRead" => $lastRead, "lastMessage" => $lastMessage, "photos" => $photos, "uids" => $uids, "photo_version" => $photoversion));
 	}
 
 	/**

--- a/js/devel/app.js
+++ b/js/devel/app.js
@@ -16,6 +16,7 @@ var Sms = {
 	unreadCountNotifStep: 12,
 	lastUnreadCountAllConv: 0,
 	lastContactListMsgDate: 0,
+	lastMessageDate: 0,
 	originalTitle: document.title,
 	photoVersion: 1,
 

--- a/js/devel/legacy.js
+++ b/js/devel/legacy.js
@@ -126,7 +126,7 @@ app.controller('OcSmsController', ['$scope', '$interval', '$timeout', '$compile'
 		$scope.checkNewMessages = function () {
 			Sms.unreadCountAllConv = 0;
 			$.getJSON(Sms.generateURL('/front-api/v1/new_messages'),
-				{'lastDate': Sms.lastContactListMsgDate},
+				{'lastDate': Sms.lastMessageDate},
 				function (jsondata, status) {
 					var bufferedContacts = [];
 
@@ -323,6 +323,7 @@ app.controller('OcSmsController', ['$scope', '$interval', '$timeout', '$compile'
 			});
 
 			Sms.lastContactListMsgDate = jsondata["lastRead"];
+			Sms.lastMessageDate = jsondata["lastMessage"];
 		};
 
 		// Return (int) msgCount, (str) htmlConversation


### PR DESCRIPTION
Using the conversation read date to check for new messages will retrieve the same message multiple times if the last read date is older than when the new message arrives.  Instead us the last message we have retrieved as the date to check for new messages from.