### PR TITLE
Fix width of message container

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -60,6 +60,7 @@
 
 #app-content-wrapper {
 	padding: 15px;
+	min-width: auto !important;
 	min-height: auto !important;
 	height: auto;
 }


### PR DESCRIPTION
The app container wrapper inherits a 100% width from  nextcloud which forces all messages to the bottom of the page below the contacts/settings panel.  Override this so they show correctly.