### PR TITLE
Fix use of insert statement without named parameter. 

### DIFF
--- a/db/conversationstatemapper.php
+++ b/db/conversationstatemapper.php
@@ -69,9 +69,9 @@ class ConversationStateMapper extends Mapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->insert('ocsms_conversation_read_states')
 			->values(array(
-				'user_id' => $userId,
-				'phone_number' => $phoneNumber,
-				'int_date' => $lastDate
+				'user_id' => $qb->createNamedParameter($userId),
+				'phone_number' => $qb->createNamedParameter($phoneNumber),
+				'int_date' => $qb->createNamedParameter($lastDate)
 			));
 		$this->db->commit();
 	}

--- a/db/smsmapper.php
+++ b/db/smsmapper.php
@@ -368,18 +368,20 @@ class SmsMapper extends Mapper {
 				$qb->execute();
 			}
 			$now = date("Y-m-d H:i:s");
-			$query = \OCP\DB::prepare('INSERT INTO *PREFIX*ocsms_smsdatas ' .
-			'(user_id, added, lastmodified, sms_flags, sms_date, sms_id,' .
-			'sms_address, sms_msg, sms_mailbox, sms_type) VALUES ' .
-			'(?,?,?,?,?,?,?,?,?,?)');
-			$result = $query->execute(array(
-				$userId, $now, $now, $smsFlags,
-				$sms["date"], (int) $sms["_id"],
-				$sms["address"], $sms["body"], (int) $sms["mbox"],
-				(int) $sms["type"]
-			));
-
-
+			$qb->insert('ocsms_smsdatas')
+				->values(array(
+					'user_id' => $qb->createNamedParameter($userId),
+					'added' => $qb->createNamedParameter($now),
+					'lastmodified' => $qb->createNamedParameter($now),
+					'sms_flags' => $qb->createNamedParameter($smsFlags),
+					'sms_date' => $qb->createNamedParameter($sms["date"]),
+					'sms_id' => $qb->createNamedParameter((int) $sms["_id"]),
+					'sms_address' => $qb->createNamedParameter($sms["address"]),
+					'sms_msg' => $qb->createNamedParameter($sms["body"]),
+					'sms_mailbox' => $qb->createNamedParameter((int) $sms["mbox"]),
+					'sms_type' => $qb->createNamedParameter((int) $sms["type"])
+				));
+			$qb->execute();
 		}
 
 		$this->db->commit();


### PR DESCRIPTION
The previous `insert` statement that I wrote should have wrapped the array values in `$qb->createNamedParameter` so that QueryBuilder does the necessary escaping.

Also convert SMS upload/insert statement to NC14 compatible. With this, I'm now able to use the latest OCSMS app to upload messages to NC14, yay!
